### PR TITLE
Fix when an img tag isn't closed

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -37,38 +37,34 @@ func ImageURLs(r io.Reader) []string {
 
 	for {
 		tt := z.Next()
-
-		switch {
-		case tt == html.ErrorToken:
+		if tt == html.ErrorToken {
 			return images
-		case tt == html.SelfClosingTagToken:
-			t := z.Token()
-
-			isImg := t.Data == "img"
-			if !isImg {
-				continue
-			}
-
-			image := getImageURL(t)
-			if image == "" {
-				continue
-			}
-
-			images = append(images, image)
 		}
+
+		t := z.Token()
+		if t.Data != "img" {
+			continue
+		}
+
+		image, ok := getImageURL(t)
+		if !ok {
+			continue
+		}
+
+		images = append(images, image)
 	}
 }
 
 // getImageURL checks if the img html.Token contains an src, if that's the
 // case returns the URL.
-func getImageURL(t html.Token) string {
+func getImageURL(t html.Token) (string, bool) {
 	for _, i := range t.Attr {
 		if i.Key == "src" || i.Key == "data-src" {
-			return i.Val
+			return i.Val, true
 		}
 	}
 
-	return ""
+	return "", false
 }
 
 // absoluteImagePath checks if the url to an image already is absolute,

--- a/parser_test.go
+++ b/parser_test.go
@@ -130,7 +130,11 @@ func TestGetImageURL(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		got := getImageURL(test.got)
+		got, ok := getImageURL(test.got)
+		if test.want == "" && ok {
+			t.Errorf("want ok = false, got true")
+		}
+
 		if got != test.want {
 			t.Errorf("want url = %q, got %q", test.want, got)
 		}
@@ -175,6 +179,10 @@ func TestImageURLs(t *testing.T) {
 		{
 			body: strings.NewReader(`<html><body><img data-src="/image.jpeg" /></body></html>`),
 			want: []string{"/image.jpeg"},
+		},
+		{
+			body: strings.NewReader(`<html><body><img src="/image.png"/ width="400"></body></html>`),
+			want: []string{"/image.png"},
 		},
 	}
 


### PR DESCRIPTION
This fixes an issue where the img tag wasn't closed. For instance when it
looked like this; `<img src="/images/bloom-filter.png"/ width="400">`. The
issue was found when looking at
http://www.allthingsdistributed.com/2017/02/bloom-filters.html.

The solution is that we look at every tag type and see if the Data contains
`img`.